### PR TITLE
trying to fix the sticky map and navbar problem

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -1,9 +1,9 @@
 #map {
-  height: 100vh;
-  width: 40%;
+  height: 70vh;
+  width: 40vw;
   margin: 8vh 0px 2vh 5vw;
   position: sticky;
-  top: 0;
+  top: 100px;
 }
 
 #map > img {


### PR DESCRIPTION
having two sticky elements on one page is tricky. I have tried to find a solution by sticking the map on top: 100px (instead of 0px which causes it to scroll underneath the navbar). but also once the map reaches its own hight on top of the browser window, it becomes scrollable itself and therefor goes underneath the navbar. therefor i made the map shorter (70vh instead of 100vh) this could be a possible fix. if you don't like the smaller map, just drop this pull request. have a look: 
![Screenshot 2020-11-26 at 21 43 06](https://user-images.githubusercontent.com/41717932/100390372-6ec68700-3030-11eb-8f8d-386875222682.png)
