### PR TITLE
changed max-height for page header

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -12,7 +12,7 @@
 
 .header {
   -webkit-animation: pulse 45s infinite alternate;
-  height: 30vh;
+  max-height: 70vh;
   margin-bottom: 5vh;
   margin-top: 8vh;
   padding: 32px;


### PR DESCRIPTION
on smaller height laptops the sentence "Share your experience ..." was poking out of the white background. I fixed that through adding max-height: 70vh 
<img width="1436" alt="Bildschirmfoto 2020-11-29 um 13 19 05" src="https://user-images.githubusercontent.com/41717932/100541696-c7bb3880-3245-11eb-887f-3095729b77d4.png">
