### PR TITLE
adjusted position sticky in show

### DIFF
--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -14,16 +14,14 @@ h1 {
 .show-right {
   float: right;
   position: sticky;
-  top: 170px;
+  top: 180px;
   height: 100%;
-  width: 25%;
-  margin-left: 5%;
+  width: 30%;
 }
 
 .show-left {
   display: inline-block;
   width: 65%;
-  margin-right: 5%;
 }
 
 


### PR DESCRIPTION
actually sticky did work also in chrome. the right column seemed like it wasn't sticky, because once it touches the footer it gets scrollable itself. if there are no reviews or not enough revues it has that behaviour bc it touches the footer. i fixed the width of the right column as you can see on the screenshot.
<img width="1411" alt="Bildschirmfoto 2020-12-01 um 20 21 05" src="https://user-images.githubusercontent.com/41717932/100786838-0520f100-3413-11eb-9af8-1b88827ea839.png">
